### PR TITLE
Workaround for xtend source file encoding problem on windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,23 @@
 
 ## run locally
 
+### using gradle 
+From main working directory run:
+
 ```bash
-gradle clean jar run
+gradlew clean jar run
 ```
-Then navigate your browser to localhost:3300.
+
+Open your browser at localhost:3300
+
+
+### using eclipse
+
+> Prerequisites
+> * You will need to have eclipse xtend plugin installed
+> * When using a windows pc: set text file encoding to UTF-8 
+> e.g. Preferences > Workspace > Text file ecoding: UTF-8. 
+> This is currently neccessary as Xtext gradle plugin seems to be using UTF-8 for encoding and not platform standard encoding as would be expected.
+
+Launch SimpleLoginServer.xtend as Java application 
+& Open your browser at localhost:3300

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,11 @@
 plugins {
+  id "java"
   id "application"
-  id "org.xtext.xtend" version "1.0.12"
+  id "org.xtext.xtend" version "1.0.15"
+}
+
+tasks.withType(JavaCompile) {
+  options.encoding = "UTF-8"
 }
 
 mainClassName = "wachtmeister.logins.simple.SimpleLoginServer"
@@ -23,7 +28,7 @@ configurations {
 
 dependencies {
   
-  compile 'com.github.oehme:xtend-contrib:1.1.0'
+  compile 'com.github.oehme:xtend-contrib:1.1.0' // transitively includes 'org.eclipse.xtend:org.eclipse.xtend.lib:x.x.x'
   
   compile 'de.neuland-bfi:jade4j:1.1.4'
   compile 'com.github.donreeal:pollbus-id:baratine-1.0.0'
@@ -41,6 +46,6 @@ dependencies {
 jar {
   dependsOn configurations.compile
   manifest {
-    attributes 'Main-Class': mainClassName
+    attributes 'Main-Class': mainClassName // kind of messy - should be done by application plugin automatically
   }
 }

--- a/src/main/java/wachtmeister/Preconditions.xtend
+++ b/src/main/java/wachtmeister/Preconditions.xtend
@@ -8,7 +8,7 @@ class Preconditions {
 
   def static <T> requireAbsence(T value, Collection<T> c) {
     if(c.contains(value))
-      throw new ValueTakenException('''Value:«value» already taken!''')
+      throw new ValueTakenException('''Value:Â«valueÂ» already taken!''')
     return value
   }
 

--- a/src/main/java/wachtmeister/api/LoginServiceREST.xtend
+++ b/src/main/java/wachtmeister/api/LoginServiceREST.xtend
@@ -103,7 +103,7 @@ class LoginServiceREST {
     override toString() {
       return '''
         RegistrationData[
-          username = «username»
+          username = Â«usernameÂ»
           password = ...
           email = ...
        '''

--- a/src/main/java/wachtmeister/logins/simple/Logins.xtend
+++ b/src/main/java/wachtmeister/logins/simple/Logins.xtend
@@ -63,7 +63,7 @@ public class Logins implements LoginsReducerSync {
     val username = pwChanged.login
     
     requireThat(username, [isLoginManaged(it)],'''
-      Trying to changed password for unmanaged login:«username»
+      Trying to changed password for unmanaged login:Â«usernameÂ»
     ''')
     
     val login = getByLogin(username)

--- a/src/main/java/wachtmeister/logins/simple/SingleAssetLoginService.xtend
+++ b/src/main/java/wachtmeister/logins/simple/SingleAssetLoginService.xtend
@@ -105,7 +105,7 @@ class SingleAssetLoginService extends Logins implements LoginService {
     requireNonEmpty(password)  
     
     if(!isLoginManaged(login))
-      throw new IllegalArgumentException('''Unknown login:«login»''')
+      throw new IllegalArgumentException('''Unknown login:Â«loginÂ»''')
     else
       _pwHashing.hash(password, result.then [ pwHash, r |
         _eventIds.next(result.then [ eventId |

--- a/src/main/java/wachtmeister/webapp/csrf/VerifyRequestOrigin.xtend
+++ b/src/main/java/wachtmeister/webapp/csrf/VerifyRequestOrigin.xtend
@@ -42,7 +42,7 @@ class VerifyRequestOrigin implements ServiceWeb {
     try {
       
       var originUrl = new URL(originHeader)
-      val reqOriginHostAndPort = originUrl.host + ":" + originUrl.port
+      val reqOriginHostAndPort = '''«originUrl.host»:«originUrl.port»'''
       
       val host = req.header(HEADERNAME_HOST)
         // assume a reverse proxy forwards host in x-forwarded-host header


### PR DESCRIPTION
Using utf-8 encoded xtend source files now.

Fixed behaviour:
Template Strings are being correctly encoded when building

Actual behaviour before fix:
Runtime errors due to wrong encoded xtend template Strings.
When build was run in git bash Xtext gradle plugin was reading files as UTF-8 - but xtend source files were using Windows default (Cp1252) encoding.